### PR TITLE
Make sure index.html is served as utf-8

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
   <head>
+    <meta charset="utf-8">
     <title>Ymacs -- An Emacs-like editor for the Web</title>
     <link rel="stylesheet" type="text/css" href="dl/new-theme/default.css" />
     <link rel="stylesheet" type="text/css" href="../src/css/ymacs.css" />


### PR DESCRIPTION
Hello Mihai,

following little change fixes breakage for me when ymacs is hosted on servers not sending utf-8 by default.

See https://github.com/anaran/ymacs/wiki/ymacs-before-serve-as-charset-utf-8.png

Would be great if this change could be integrated, unless you find something wrong with this.

Best regards
Adrian
