### PR TITLE
This fixes an issue that allowed the handler for ( to take precedence

### DIFF
--- a/src/js/ymacs-keymap.js
+++ b/src/js/ymacs-keymap.js
@@ -156,7 +156,7 @@ DEFINE_CLASS("Ymacs_Keymap", null, function(D, P){
                 if (handler instanceof Array)
                     $BREAK();
             }
-            else if (handler) {
+            else {
                 handler = null;
                 $BREAK();
             }


### PR DESCRIPTION
over C-x (.  The loop previously only terminated if a gap would exist
in the key map (such as if C-x and e both had handlers, but q doesn't
have any handler in the sequence C-x q e).  If a two key sequence existed
where both had handlers, but the handlers were disjoint (that is, the
first key had a single-key handler and the second key also had a single
key handler, we'd drop out of the loop with handler set and erroneously
return it, preempting a more specific match in a different keymap layer.
I believe this change doesn't break anything else, although my testing
is far from extensive.
