### PR TITLE
improve code for filename completion (abstract the local filesystem impl...

### DIFF
--- a/src/js/ymacs-keymap-emacs.js
+++ b/src/js/ymacs-keymap-emacs.js
@@ -219,6 +219,7 @@ DEFINE_SINGLETON("Ymacs_Keymap_Emacs", Ymacs_Keymap, function(D, P){
         "C-x C-f"                                 : "find_file",
         "C-x C-w"                                 : "write_file",
         "C-x C-s"                                 : "save_buffer",
+        "C-x s"                                   : "save_some_buffers",
 
         // others
         "C-x =": function() {

--- a/src/js/ymacs-minibuffer.js
+++ b/src/js/ymacs-minibuffer.js
@@ -256,10 +256,13 @@ Ymacs_Buffer.newMode("minibuffer_mode", function(){
             var self = this;
             self.cmd("minibuffer_replace_input_by_current_dir", function () {
                 read_with_continuation.call(self, filename_completion, cont, function(mb, name, cont2){
-                    self.ymacs.fs_getFileContents(name, true, function (ret, stamp) {
-                        if (!ret)
+                    self.ymacs.fs_fileType(name, function (type) {
+                        if (type == null) {
                             mb.signalError("No such file: " + name);
-                        cont2(ret);
+                            cont2(false);
+                        } else {
+                            cont2(true);
+                        }
                     });
                 });
             });

--- a/src/js/ymacs.js
+++ b/src/js/ymacs.js
@@ -489,19 +489,32 @@ DEFINE_CLASS("Ymacs", DlLayout, function(D, P, DOM){
 
     /* -----[ filesystem operations ]----- */
 
+    P.fs_fileType = function(name, cont) {
+        var self = this;
+//        setTimeout(function () { // uncomment to make it async, for testing
+        var files = this.ls_getFileDirectory(name, false);
+        alert("path="+files.path+" other="+files.other);
+        cont(null);
+//        }, 10);
+    };
+
     P.fs_getFileContents = function(name, nothrow, cont) {
         var self = this;
 //        setTimeout(function () { // uncomment to make it async, for testing
         var code = self.ls_getFileContents(name, nothrow);
-        cont(code, code); // second parameter is file stamp, which should be last modification time
+        cont(code, code); // second parameter is file stamp, on a real fs it should be last modification time
 //        }, 10);
     };
 
-    P.fs_setFileContents = function(name, content, cont) {
+    P.fs_setFileContents = function(name, content, stamp, cont) {
         var self = this;
 //        setTimeout(function () { // uncomment to make it async, for testing
-        self.ls_setFileContents(name, content);
-        cont(content); // return content as stamp, should be last modification time
+        if (stamp && (self.ls_getFileContents(name, true) || "") != stamp) {
+            cont(null); // did not change file because stamp is wrong
+        } else {
+            self.ls_setFileContents(name, content);
+            cont(content); // return content as stamp, on a real fs it should be last modification time
+        }
 //        }, 10);
     };
 


### PR DESCRIPTION
The filename completion code relied on the representation of the local filesystem.  This has been abstracted.  Filename completion also starts off with the current directory.  Some code has been added to avoid duplicate buffers and to ask the user to discard changes, reread modified files, etc.
